### PR TITLE
feat: add module to fetch subresources and links via network requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 *.map
 yarn.lock
 package-lock.json
+dist/

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,7 @@
-import puppeteer, { type Page, type LaunchOptions } from "puppeteer";
+import puppeteer, {
+	type LaunchOptions,
+	type HTTPResponse,
+} from "puppeteer";
 
 export type ResourceType =
 	| "stylesheet"
@@ -23,292 +26,121 @@ export interface Options {
 	puppeteerOptions?: LaunchOptions;
 }
 
+function mapResourceType(
+	response: HTTPResponse,
+	mainFrameUrl: string,
+): ResourceType | null {
+	const request = response.request();
+	const type = request.resourceType();
+	const url = response.url();
+
+	// Skip data URLs
+	if (url.startsWith("data:")) return null;
+
+	const contentType = response.headers()["content-type"] || "";
+	switch (type) {
+		case "stylesheet":
+			return "stylesheet";
+		case "script":
+			return "script";
+		case "image":
+			// favicon detection
+			if (url.match(/favicon|apple-touch-icon/i)) {
+				return "favicon";
+			}
+			return "image";
+		case "media": {
+			if (contentType.startsWith("audio/")) return "audio";
+			if (contentType.startsWith("video/")) return "video";
+			return null;
+		}
+		case "font":
+			return "font";
+		case "manifest":
+			return "manifest";
+		case "document":
+			if (contentType.startsWith("image/svg")) return "image";
+			// iframe detection
+			if (request.frame()?.parentFrame()) {
+				return "iframe";
+			}
+			return null;
+		case "other": {
+			if (
+				contentType.includes("application/pdf") ||
+				contentType.includes("application/octet-stream")
+			) {
+				return "object";
+			}
+			return null;
+		}
+		default:
+			return null;
+	}
+}
+
 export async function* getAllSubResources(
 	url: URL,
 	options: Partial<Options> = {},
 ): AsyncGenerator<Resource, void, undefined> {
 	let caughtError;
 	const browser = await puppeteer.launch(options.puppeteerOptions);
+
 	try {
 		const page = await browser.newPage();
-		const response = await page.goto(url.href, {});
+
+		const seen = new Set<string>();
+		const queue: Resource[] = [];
+
+		page.on("response", response => {
+			const resourceType = mapResourceType(response, url.href);
+			if (!resourceType) return;
+
+			const resourceUrl = response.url();
+			if (seen.has(resourceUrl)) return;
+
+			seen.add(resourceUrl);
+			queue.push({
+				type: resourceType,
+				url: resourceUrl,
+			});
+		});
+
+		const response = await page.goto(url.href, {
+			waitUntil: "networkidle0",
+		});
 
 		if (!response || !response.ok()) {
 			const reason = response ? `. HTTP ${response.status()}` : "";
 			throw new Error(`Failed to navigate to ${url}${reason}`);
 		}
 
-		yield* await getStyleSheets(page);
-		yield* await getImportedStyleSheets(page);
-		yield* await getScripts(page);
-		yield* await getMedia(page);
-		yield* await getStyleSheetImages(page);
-		yield* await getFonts(page);
-		yield* await getFavicons(page);
-		if (options?.links) yield* await getLinks(page);
-		yield* await getIframes(page);
-		yield* await getMiscResources(page);
+		// Yield network resources
+		for (const resource of queue) {
+			yield resource;
+		}
+
+		if (options.links) {
+			const links = await page.$$eval("a[href]", elems =>
+				(elems as HTMLAnchorElement[])
+					.filter(el => el instanceof HTMLAnchorElement)
+					.map(el => ({
+						type: "link" as const,
+						url: el.href,
+					})),
+			);
+
+			for (const link of links) {
+				if (!seen.has(link.url)) {
+					seen.add(link.url);
+					yield link;
+				}
+			}
+		}
 	} catch (error) {
 		caughtError = error;
 	} finally {
 		await browser.close();
 		if (caughtError) throw caughtError;
 	}
-}
-
-async function getStyleSheets(page: Page) {
-	return await page.$$eval(`link[rel~="stylesheet"]`, elems => {
-		return (elems as HTMLLinkElement[]).map(elem => {
-			return {
-				type: "stylesheet" as const,
-				url: elem.href,
-			};
-		});
-	});
-}
-
-async function getImportedStyleSheets(page: Page) {
-	return await page.evaluate(pageURL => {
-		const importedStylesheets = [];
-		for (const stylesheet of document.styleSheets) {
-			try {
-				// Cannot read cssRules in cross-origin stylesheets
-				stylesheet.cssRules;
-			} catch {
-				continue;
-			}
-			const baseURL = stylesheet.href || (pageURL as string);
-			for (const rule of stylesheet.cssRules) {
-				if (rule instanceof CSSImportRule) {
-					const url = new URL(rule.href, baseURL).href;
-					importedStylesheets.push({
-						type: "stylesheet" as const,
-						url,
-					});
-				}
-			}
-		}
-		return importedStylesheets;
-	}, page.url());
-}
-
-async function getScripts(page: Page) {
-	return await page.$$eval(`script[src]`, elems => {
-		return (elems as HTMLScriptElement[]).map(elem => {
-			return {
-				type: "script" as const,
-				url: elem.src,
-			};
-		});
-	});
-}
-
-async function getMedia(page: Page) {
-	type MediaResource = HTMLImageElement | HTMLVideoElement | HTMLSourceElement;
-	const mediaSources = await page.$$eval(
-		`img[src], video > source[src], video[src], audio[src]`,
-		elems => {
-			const images = [];
-			for (const elem of elems as MediaResource[]) {
-				let type;
-				if (elem instanceof HTMLImageElement) {
-					type = "image" as const;
-				} else if (elem instanceof HTMLVideoElement) {
-					type = "video" as const;
-				} else if (elem instanceof HTMLSourceElement) {
-					if (elem.parentElement instanceof HTMLVideoElement) {
-						type = "video" as const;
-					} else {
-						type = "audio" as const;
-					}
-				} else {
-					throw new Error("Reached unreachable code.");
-				}
-				images.push({
-					type,
-					url: elem.src,
-				});
-			}
-			return images;
-		},
-	);
-
-	const imageSrcSets = await page.$$eval(
-		`img[srcset], picture > source[srcset]`,
-		(elems, pageURL) => {
-			const images = [];
-			for (const elem of elems as (HTMLImageElement | HTMLSourceElement)[]) {
-				images.push(
-					...elem.srcset
-						.trim()
-						.split(/,\s+/)
-						.filter(s => s.trim())
-						.map(part => {
-							const src = part.trim().split(/\s+/, 2)[0];
-							const url = new URL(src, pageURL as string).href;
-							return {
-								type: "image" as const,
-								url,
-							};
-						}),
-				);
-			}
-			return images;
-		},
-		page.url(),
-	);
-
-	return [...mediaSources, ...imageSrcSets];
-}
-
-async function getStyleSheetImages(page: Page) {
-	return await page.evaluate(pageURL => {
-		const urls = [];
-		for (const stylesheet of document.styleSheets) {
-			try {
-				// Cannot read cssRules in cross-origin stylesheets
-				stylesheet.cssRules;
-			} catch {
-				continue;
-			}
-			const baseURL = stylesheet.href || (pageURL as string);
-			for (const rule of stylesheet.cssRules) {
-				if (rule instanceof CSSStyleRule && rule.style.backgroundImage) {
-					urls.push(
-						...rule.style.backgroundImage
-							.split(",")
-							.map(s => s.match(/url\("([^)]+)"\)/))
-							.map(s => (s ? s[1].trim() : undefined))
-							.filter((s): s is string => !!s)
-							.map(url => new URL(url, baseURL).href),
-					);
-				} else if (rule instanceof CSSStyleRule && rule.style.content) {
-					const match = rule.style.content.match(/url\("([^)]+)"\)/);
-					if (!match) continue;
-					const url = match[1].trim();
-					if (!url || new URL(url, baseURL).protocol === "data:") continue;
-					urls.push(new URL(url, baseURL).href);
-				}
-			}
-		}
-		return urls.map(url => ({
-			type: "image" as const,
-			url,
-		}));
-	}, page.url());
-}
-
-async function getFonts(page: Page) {
-	return await page.evaluate(pageURL => {
-		const urls = [];
-		for (const stylesheet of document.styleSheets) {
-			try {
-				// Cannot read cssRules in cross-origin stylesheets
-				stylesheet.cssRules;
-			} catch {
-				continue;
-			}
-
-			const baseURL = stylesheet.href || (pageURL as string);
-			for (const rule of stylesheet.cssRules) {
-				if (rule instanceof CSSFontFaceRule && (rule.style as any).src) {
-					const src = (rule.style as any).src as string;
-					urls.push(
-						...src
-							.split(",")
-							.map(s => s.match(/url\("([^)]+)"\)/))
-							.map(s => (s ? s[1].trim() : undefined))
-							.filter((s): s is string => !!s)
-							.map(url => new URL(url, baseURL).href),
-					);
-				}
-			}
-		}
-
-		return urls.map(url => ({
-			type: "font" as const,
-			url,
-		}));
-	}, page.url());
-}
-
-async function getIframes(page: Page) {
-	return await page.$$eval(`iframe[src]`, elems => {
-		const iframes = [];
-		for (const elem of elems as HTMLIFrameElement[]) {
-			iframes.push({
-				type: "iframe" as const,
-				url: elem.src,
-			});
-		}
-		return iframes;
-	});
-}
-
-async function getFavicons(page: Page) {
-	return await page.$$eval(
-		`link[rel~='icon'], link[rel~='apple-touch-icon']`,
-		elems => {
-			const favicons = [];
-			for (const elem of elems as HTMLLinkElement[]) {
-				if (!elem.href) continue;
-				if (new URL(elem.href).protocol === "data:") continue;
-
-				favicons.push({
-					type: "favicon" as const,
-					url: elem.href,
-				});
-			}
-			return favicons;
-		},
-	);
-}
-
-async function getLinks(page: Page) {
-	return await page.$$eval(`a[href]`, elems => {
-		const links = [];
-		for (const elem of elems) {
-			if (!(elem instanceof HTMLAnchorElement)) {
-				continue; // exclude SVGAElement
-			}
-			links.push({
-				type: "link" as const,
-				url: elem.href,
-			});
-		}
-		return links;
-	});
-}
-
-async function getMiscResources(page: Page) {
-	const manifest = await page
-		.$eval(`link[rel~="manifest"]`, elem => {
-			return {
-				type: "manifest" as const,
-				url: (elem as HTMLLinkElement).href,
-			};
-		})
-		.catch(() => null);
-
-	const dataObjects = await page.$$eval(
-		`object[data]`,
-		(elems, pageURL) => {
-			const objects = [];
-			for (const elem of elems as HTMLObjectElement[]) {
-				try {
-					const url = new URL(elem.data, pageURL as string);
-					objects.push({
-						type: "object" as const,
-						url: url.href,
-					});
-				} catch {}
-			}
-			return objects;
-		},
-		page.url(),
-	);
-
-	return [manifest, ...dataObjects].filter(
-		(resource): resource is NonNullable<typeof resource> => resource !== null,
-	);
 }

--- a/package.json
+++ b/package.json
@@ -11,10 +11,22 @@
 		"dev": "tsc -p tsconfig.json --watch"
 	},
 	"files": [
-		"index.js",
-		"index.d.ts",
-		"index.js.map"
+		"dist"
 	],
+	"exports": {
+		".": {
+			"types": "./dist/dom.d.ts",
+			"import": "./dist/dom.js"
+		},
+		"./dom": {
+			"types": "./dist/dom.d.ts",
+			"import": "./dist/dom.js"
+		},
+		"./network": {
+			"types": "./dist/network.d.ts",
+			"import": "./dist/network.js"
+		}
+	},
 	"type": "module",
 	"dependencies": {
 		"puppeteer": "^24"

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -1,6 +1,6 @@
-import puppeteer, { type Page, type LaunchOptions } from "puppeteer";
+import puppeteer, { type Page } from "puppeteer";
 
-import type { Options, Resource, ResourceType } from "./types.js";
+import type { Options, Resource } from "./types.js";
 
 export async function* getAllSubResources(
 	url: URL,

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -1,0 +1,293 @@
+import puppeteer, { type Page, type LaunchOptions } from "puppeteer";
+
+import type { Options, Resource, ResourceType } from "./types.js";
+
+export async function* getAllSubResources(
+	url: URL,
+	options: Partial<Options> = {},
+): AsyncGenerator<Resource, void, undefined> {
+	let caughtError;
+	const browser = await puppeteer.launch(options.puppeteerOptions);
+	try {
+		const page = await browser.newPage();
+		const response = await page.goto(url.href, {});
+
+		if (!response || !response.ok()) {
+			const reason = response ? `. HTTP ${response.status()}` : "";
+			throw new Error(`Failed to navigate to ${url}${reason}`);
+		}
+
+		yield* await getStyleSheets(page);
+		yield* await getImportedStyleSheets(page);
+		yield* await getScripts(page);
+		yield* await getMedia(page);
+		yield* await getStyleSheetImages(page);
+		yield* await getFonts(page);
+		yield* await getFavicons(page);
+		if (options?.links) yield* await getLinks(page);
+		yield* await getIframes(page);
+		yield* await getMiscResources(page);
+	} catch (error) {
+		caughtError = error;
+	} finally {
+		await browser.close();
+		if (caughtError) throw caughtError;
+	}
+}
+
+async function getStyleSheets(page: Page) {
+	return await page.$$eval(`link[rel~="stylesheet"]`, elems => {
+		return (elems as HTMLLinkElement[]).map(elem => {
+			return {
+				type: "stylesheet" as const,
+				url: elem.href,
+			};
+		});
+	});
+}
+
+async function getImportedStyleSheets(page: Page) {
+	return await page.evaluate(pageURL => {
+		const importedStylesheets = [];
+		for (const stylesheet of document.styleSheets) {
+			try {
+				// Cannot read cssRules in cross-origin stylesheets
+				stylesheet.cssRules;
+			} catch {
+				continue;
+			}
+			const baseURL = stylesheet.href || (pageURL as string);
+			for (const rule of stylesheet.cssRules) {
+				if (rule instanceof CSSImportRule) {
+					const url = new URL(rule.href, baseURL).href;
+					importedStylesheets.push({
+						type: "stylesheet" as const,
+						url,
+					});
+				}
+			}
+		}
+		return importedStylesheets;
+	}, page.url());
+}
+
+async function getScripts(page: Page) {
+	return await page.$$eval(`script[src]`, elems => {
+		return (elems as HTMLScriptElement[]).map(elem => {
+			return {
+				type: "script" as const,
+				url: elem.src,
+			};
+		});
+	});
+}
+
+async function getMedia(page: Page) {
+	type MediaResource = HTMLImageElement | HTMLVideoElement | HTMLSourceElement;
+	const mediaSources = await page.$$eval(
+		`img[src], video > source[src], video[src], audio[src]`,
+		elems => {
+			const images = [];
+			for (const elem of elems as MediaResource[]) {
+				let type;
+				if (elem instanceof HTMLImageElement) {
+					type = "image" as const;
+				} else if (elem instanceof HTMLVideoElement) {
+					type = "video" as const;
+				} else if (elem instanceof HTMLSourceElement) {
+					if (elem.parentElement instanceof HTMLVideoElement) {
+						type = "video" as const;
+					} else {
+						type = "audio" as const;
+					}
+				} else {
+					throw new Error("Reached unreachable code.");
+				}
+				images.push({
+					type,
+					url: elem.src,
+				});
+			}
+			return images;
+		},
+	);
+
+	const imageSrcSets = await page.$$eval(
+		`img[srcset], picture > source[srcset]`,
+		(elems, pageURL) => {
+			const images = [];
+			for (const elem of elems as (HTMLImageElement | HTMLSourceElement)[]) {
+				images.push(
+					...elem.srcset
+						.trim()
+						.split(/,\s+/)
+						.filter(s => s.trim())
+						.map(part => {
+							const src = part.trim().split(/\s+/, 2)[0];
+							const url = new URL(src, pageURL as string).href;
+							return {
+								type: "image" as const,
+								url,
+							};
+						}),
+				);
+			}
+			return images;
+		},
+		page.url(),
+	);
+
+	return [...mediaSources, ...imageSrcSets];
+}
+
+async function getStyleSheetImages(page: Page) {
+	return await page.evaluate(pageURL => {
+		const urls = [];
+		for (const stylesheet of document.styleSheets) {
+			try {
+				// Cannot read cssRules in cross-origin stylesheets
+				stylesheet.cssRules;
+			} catch {
+				continue;
+			}
+			const baseURL = stylesheet.href || (pageURL as string);
+			for (const rule of stylesheet.cssRules) {
+				if (rule instanceof CSSStyleRule && rule.style.backgroundImage) {
+					urls.push(
+						...rule.style.backgroundImage
+							.split(",")
+							.map(s => s.match(/url\("([^)]+)"\)/))
+							.map(s => (s ? s[1].trim() : undefined))
+							.filter((s): s is string => !!s)
+							.map(url => new URL(url, baseURL).href),
+					);
+				} else if (rule instanceof CSSStyleRule && rule.style.content) {
+					const match = rule.style.content.match(/url\("([^)]+)"\)/);
+					if (!match) continue;
+					const url = match[1].trim();
+					if (!url || new URL(url, baseURL).protocol === "data:") continue;
+					urls.push(new URL(url, baseURL).href);
+				}
+			}
+		}
+		return urls.map(url => ({
+			type: "image" as const,
+			url,
+		}));
+	}, page.url());
+}
+
+async function getFonts(page: Page) {
+	return await page.evaluate(pageURL => {
+		const urls = [];
+		for (const stylesheet of document.styleSheets) {
+			try {
+				// Cannot read cssRules in cross-origin stylesheets
+				stylesheet.cssRules;
+			} catch {
+				continue;
+			}
+
+			const baseURL = stylesheet.href || (pageURL as string);
+			for (const rule of stylesheet.cssRules) {
+				if (rule instanceof CSSFontFaceRule && (rule.style as any).src) {
+					const src = (rule.style as any).src as string;
+					urls.push(
+						...src
+							.split(",")
+							.map(s => s.match(/url\("([^)]+)"\)/))
+							.map(s => (s ? s[1].trim() : undefined))
+							.filter((s): s is string => !!s)
+							.map(url => new URL(url, baseURL).href),
+					);
+				}
+			}
+		}
+
+		return urls.map(url => ({
+			type: "font" as const,
+			url,
+		}));
+	}, page.url());
+}
+
+async function getIframes(page: Page) {
+	return await page.$$eval(`iframe[src]`, elems => {
+		const iframes = [];
+		for (const elem of elems as HTMLIFrameElement[]) {
+			iframes.push({
+				type: "iframe" as const,
+				url: elem.src,
+			});
+		}
+		return iframes;
+	});
+}
+
+async function getFavicons(page: Page) {
+	return await page.$$eval(
+		`link[rel~='icon'], link[rel~='apple-touch-icon']`,
+		elems => {
+			const favicons = [];
+			for (const elem of elems as HTMLLinkElement[]) {
+				if (!elem.href) continue;
+				if (new URL(elem.href).protocol === "data:") continue;
+
+				favicons.push({
+					type: "favicon" as const,
+					url: elem.href,
+				});
+			}
+			return favicons;
+		},
+	);
+}
+
+async function getLinks(page: Page) {
+	return await page.$$eval(`a[href]`, elems => {
+		const links = [];
+		for (const elem of elems) {
+			if (!(elem instanceof HTMLAnchorElement)) {
+				continue; // exclude SVGAElement
+			}
+			links.push({
+				type: "link" as const,
+				url: elem.href,
+			});
+		}
+		return links;
+	});
+}
+
+async function getMiscResources(page: Page) {
+	const manifest = await page
+		.$eval(`link[rel~="manifest"]`, elem => {
+			return {
+				type: "manifest" as const,
+				url: (elem as HTMLLinkElement).href,
+			};
+		})
+		.catch(() => null);
+
+	const dataObjects = await page.$$eval(
+		`object[data]`,
+		(elems, pageURL) => {
+			const objects = [];
+			for (const elem of elems as HTMLObjectElement[]) {
+				try {
+					const url = new URL(elem.data, pageURL as string);
+					objects.push({
+						type: "object" as const,
+						url: url.href,
+					});
+				} catch {}
+			}
+			return objects;
+		},
+		page.url(),
+	);
+
+	return [manifest, ...dataObjects].filter(
+		(resource): resource is NonNullable<typeof resource> => resource !== null,
+	);
+}

--- a/src/network.ts
+++ b/src/network.ts
@@ -1,7 +1,4 @@
-import puppeteer, {
-	type LaunchOptions,
-	type HTTPResponse,
-} from "puppeteer";
+import puppeteer, { type HTTPResponse } from "puppeteer";
 
 import type { Options, Resource, ResourceType } from "./types.js";
 

--- a/src/network.ts
+++ b/src/network.ts
@@ -3,28 +3,7 @@ import puppeteer, {
 	type HTTPResponse,
 } from "puppeteer";
 
-export type ResourceType =
-	| "stylesheet"
-	| "script"
-	| "image"
-	| "favicon"
-	| "video"
-	| "audio"
-	| "object"
-	| "iframe"
-	| "link"
-	| "font"
-	| "manifest";
-
-export interface Resource {
-	type: ResourceType;
-	url: string;
-}
-
-export interface Options {
-	links: boolean;
-	puppeteerOptions?: LaunchOptions;
-}
+import type { Options, Resource, ResourceType } from "./types.js";
 
 function mapResourceType(
 	response: HTTPResponse,

--- a/src/network.ts
+++ b/src/network.ts
@@ -4,7 +4,7 @@ import type { Options, Resource, ResourceType } from "./types.js";
 
 function mapResourceType(
 	response: HTTPResponse,
-	mainFrameUrl: string,
+	_mainFrameUrl: string,
 ): ResourceType | null {
 	const request = response.request();
 	const type = request.resourceType();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,22 @@
+export type ResourceType =
+	| "stylesheet"
+	| "script"
+	| "image"
+	| "favicon"
+	| "video"
+	| "audio"
+	| "object"
+	| "iframe"
+	| "link"
+	| "font"
+	| "manifest";
+
+export interface Resource {
+	type: ResourceType;
+	url: string;
+}
+
+export interface Options {
+	links: boolean;
+	puppeteerOptions?: import("puppeteer").LaunchOptions;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
 		"strict": true,
 		"verbatimModuleSyntax": true,
 		"erasableSyntaxOnly": true,
-		"esModuleInterop": true
+		"esModuleInterop": true,
+		"outDir": "dist"
 	}
 }


### PR DESCRIPTION
That PR uses puppeteer to detect all the resources loaded by the page instead of parsing the document.

Fix #8 