### PR TITLE
fix: export types 

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 			"import": "./dist/types.js"
 		}
 	},
+	"types": "./dist/types.d.ts",
 	"type": "module",
 	"dependencies": {
 		"puppeteer": "^24"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
 		"./network": {
 			"types": "./dist/network.d.ts",
 			"import": "./dist/network.js"
+		},
+		"./types": {
+			"types": "./dist/types.d.ts",
+			"import": "./dist/types.js"
 		}
 	},
 	"type": "module",


### PR DESCRIPTION
[spec-prod relies on `ResourceType`](https://github.com/w3c/spec-prod/blob/main/src/build.ts#L5) so we need to export it as well.